### PR TITLE
refactor: make sure Brew only has a single constructor

### DIFF
--- a/src/com/dre/brewery/BCauldron.java
+++ b/src/com/dre/brewery/BCauldron.java
@@ -31,6 +31,18 @@ public class BCauldron {
 		LAVA,
 		SNOW;
 
+		public String toString() {
+			switch (this) {
+				case WATER:
+					return "water";
+				case LAVA:
+					return "lava";
+				case SNOW:
+					return "snow";
+				default:
+					return "water";
+			}
+		}
 		public static LiquidType fromString(String string) {
 			switch (string.toLowerCase()) {
 				case "water":

--- a/src/com/dre/brewery/BIngredients.java
+++ b/src/com/dre/brewery/BIngredients.java
@@ -1,5 +1,6 @@
 package com.dre.brewery;
 
+import com.dre.brewery.BCauldron.LiquidType;
 import com.dre.brewery.api.events.brew.BrewModifyEvent;
 import com.dre.brewery.lore.Base91EncoderStream;
 import com.dre.brewery.lore.BrewLore;
@@ -123,7 +124,7 @@ public class BIngredients {
 			int quality = (int) Math.round((getIngredientQuality(cookRecipe) + getCookingQuality(cookRecipe, false)) / 2.0);
 			int alc = (int) Math.round(cookRecipe.getAlcohol() * ((float) quality / 10.0f));
 			P.p.debugLog("cooked potion has Quality: " + quality + ", Alc: " + alc);
-			brew = new Brew(quality, alc, cookRecipe, this);
+			brew = new Brew(this, quality, alc, (byte)0, quality, alc, liquidType, cookedName, false, false, false, 0);
 			BrewLore lore = new BrewLore(brew, potionMeta);
 			lore.updateQualityStars(false);
 			lore.updateCustomLore();
@@ -137,7 +138,7 @@ public class BIngredients {
 
 		} else {
 			// new base potion
-			brew = new Brew(this);
+			brew = new Brew(this, 0, 0, (byte)0, (float)0.0, (float)0.0, liquidType, null, false, false, false, 0);
 
 			if (state <= 0) {
 				cookedName = GetText.tr("Muddy Brew");
@@ -530,12 +531,12 @@ public class BIngredients {
 		}
 	}
 
-	public static BIngredients load(DataInputStream in, short dataVersion) throws IOException {
+	public static BIngredients load(DataInputStream in) throws IOException {
 		int cookedTime = in.readInt();
 		byte size = in.readByte();
 		List<Ingredient> ing = new ArrayList<>(size);
 		for (; size > 0; size--) {
-			ItemLoader itemLoader = new ItemLoader(dataVersion, in, in.readUTF());
+			ItemLoader itemLoader = new ItemLoader(in, in.readUTF());
 			if (!P.p.ingredientLoaders.containsKey(itemLoader.getSaveID())) {
 				P.p.errorLog("Ingredient Loader not found: " + itemLoader.getSaveID());
 				break;

--- a/src/com/dre/brewery/BIngredients.java
+++ b/src/com/dre/brewery/BIngredients.java
@@ -350,6 +350,7 @@ public class BIngredients {
 			}
 		}
 
+		assert matchingRecipes.size() > 0 : "we must have at least 1 matching recipe";
 		return matchingRecipes.get(ThreadLocalRandom.current().nextInt(matchingRecipes.size()));
 	}
 

--- a/src/com/dre/brewery/Brew.java
+++ b/src/com/dre/brewery/Brew.java
@@ -644,7 +644,7 @@ public class Brew implements Cloneable {
 		// Distill Lore
 		if (currentRecipe != null && BConfig.colorInBrewer != BrewLore.hasColorLore(potionMeta)) {
 			lore.convertLore(BConfig.colorInBrewer);
-		} else {
+		} else if (currentRecipe != null) {
 			lore.updateQualityStars(BConfig.colorInBrewer);
 			lore.updateCustomLore();
 			lore.updateDistillLore(BConfig.colorInBrewer);

--- a/src/com/dre/brewery/filedata/BData.java
+++ b/src/com/dre/brewery/filedata/BData.java
@@ -198,7 +198,7 @@ public class BData {
 	public static BIngredients deserializeIngredients(String mat) {
 		try (DataInputStream in = new DataInputStream(new Base91DecoderStream(new ByteArrayInputStream(mat.getBytes())))) {
 			byte ver = in.readByte();
-			return BIngredients.load(in, ver);
+			return BIngredients.load(in);
 		} catch (IOException e) {
 			e.printStackTrace();
 			return new BIngredients();

--- a/src/com/dre/brewery/recipe/BRecipe.java
+++ b/src/com/dre/brewery/recipe/BRecipe.java
@@ -566,7 +566,7 @@ public class BRecipe {
 
 		BIngredients bIngredients = new BIngredients(list, cookingTime);
 
-		return new Brew(bIngredients, quality, 0, distillruns, getAge(), wood, getLiquidType(), getRecipeName(), false, true, 0);
+		return new Brew(bIngredients, quality, 0, distillruns, getAge(), wood, getLiquidType(), getRecipeName(), false, true, false, 0);
 	}
 
 	public void updateAcceptedLists() {

--- a/src/com/dre/brewery/recipe/ItemLoader.java
+++ b/src/com/dre/brewery/recipe/ItemLoader.java
@@ -3,19 +3,12 @@ package com.dre.brewery.recipe;
 import java.io.DataInputStream;
 
 public class ItemLoader {
-
-	private final int version;
 	private final DataInputStream in;
 	private final String saveID;
 
-	public ItemLoader(int version, DataInputStream in, String saveID) {
-		this.version = version;
+	public ItemLoader(DataInputStream in, String saveID) {
 		this.in = in;
 		this.saveID = saveID;
-	}
-
-	public int getVersion() {
-		return version;
 	}
 
 	public DataInputStream getInputStream() {


### PR DESCRIPTION
This makes it much easier to uphold invariants, such as liquidType not being null.

Fixes #9.