### PR TITLE
Added recipe description and ability to hide recipes from collection

### DIFF
--- a/resources/config/v13/en/config.yml
+++ b/resources/config/v13/en/config.yml
@@ -138,7 +138,7 @@ customItems:
 # You only need to add something here if you want to specify a custom name or color for the base potion
 
  # name: Name of the base potion coming out of the Cauldron (Formatting codes possible: such as &6)
- # description: List of text that shows when the brew hasn't been crafted yet in the collection menu (Formatting codes possible: such as &6)
+ # undiscoveredLore: List of text that shows when the brew hasn't been crafted yet in the collection menu (Formatting codes possible: such as &6)
  # hidden: Whether to hide the brew from the collection menu, defaults to false
  # ingredients: List of 'material/amount'
  #   With an item in your hand, use /brew ItemName to get its material for use in a recipe
@@ -159,7 +159,7 @@ cauldron:
   # Example with all possible entries
   ex:
     name: Example
-    description:
+    undiscoveredLore:
       - An example for a Base Potion
     hidden: false
     ingredients:
@@ -407,7 +407,7 @@ cauldron:
 # -- Recipes for Potions --
 
 # name: Different names for bad/normal/good (Formatting codes possible: such as &6)
-# description: List of text that shows when the brew hasn't been crafted yet in the collection menu (Formatting codes possible: such as &6)
+# undiscoveredLore: List of text that shows when the brew hasn't been crafted yet in the collection menu (Formatting codes possible: such as &6)
 # hidden: Whether to hide the brew from the collection menu, defaults to false
 # ingredients: List of 'material/amount'
 #   With an item in your hand, use /brew ItemName to get its material for use in a recipe
@@ -445,7 +445,7 @@ recipes:
   #  Example Recipe with every possible entry first:
   ex:
     name: Bad Example/Example/Good Example
-    description:
+    undiscoveredLore:
       - An example brew
     hidden: false
     ingredients:

--- a/resources/config/v13/en/config.yml
+++ b/resources/config/v13/en/config.yml
@@ -138,6 +138,8 @@ customItems:
 # You only need to add something here if you want to specify a custom name or color for the base potion
 
  # name: Name of the base potion coming out of the Cauldron (Formatting codes possible: such as &6)
+ # description: List of text that shows when the brew hasn't been crafted yet in the collection menu (Formatting codes possible: such as &6)
+ # hidden: Whether to hide the brew from the collection menu, defaults to false
  # ingredients: List of 'material/amount'
  #   With an item in your hand, use /brew ItemName to get its material for use in a recipe
  #   (Item-ids instead of material are not supported by bukkit anymore and will not work)
@@ -157,6 +159,9 @@ cauldron:
   # Example with all possible entries
   ex:
     name: Example
+    description:
+      - An example for a Base Potion
+    hidden: false
     ingredients:
       - Bedrock/2
       - Diamond
@@ -402,6 +407,8 @@ cauldron:
 # -- Recipes for Potions --
 
 # name: Different names for bad/normal/good (Formatting codes possible: such as &6)
+# description: List of text that shows when the brew hasn't been crafted yet in the collection menu (Formatting codes possible: such as &6)
+# hidden: Whether to hide the brew from the collection menu, defaults to false
 # ingredients: List of 'material/amount'
 #   With an item in your hand, use /brew ItemName to get its material for use in a recipe
 #   (Item-ids instead of material are not supported by bukkit anymore and will not work)
@@ -438,6 +445,9 @@ recipes:
   #  Example Recipe with every possible entry first:
   ex:
     name: Bad Example/Example/Good Example
+    description:
+      - An example brew
+    hidden: false
     ingredients:
       - Diamond/1
       - Spruce_Planks/8
@@ -454,7 +464,7 @@ recipes:
     difficulty: 3
     alcohol: 14
     lore:
-      - This is an examble brew
+      - This is an example brew
       - ++Just a normal Example
       - This text would be on the brew
       - + Smells disgusting

--- a/src/com/dre/brewery/listeners/CommandListener.java
+++ b/src/com/dre/brewery/listeners/CommandListener.java
@@ -224,7 +224,7 @@ public class CommandListener implements CommandExecutor {
 				ItemMeta itemMeta = item.getItemMeta();
 				itemMeta.setDisplayName(meta.getDisplayName());
 				item.setItemMeta(itemMeta);
-				List<String> lore = recipe.getDescription() == null ? null : recipe.getDescription().stream()
+				List<String> lore = recipe.getUndiscoveredLore() == null ? null : recipe.getUndiscoveredLore().stream()
 					.map(line -> "§r§f" + line)
 					.toList();
 				item.setLore(lore);

--- a/src/com/dre/brewery/listeners/CommandListener.java
+++ b/src/com/dre/brewery/listeners/CommandListener.java
@@ -224,6 +224,10 @@ public class CommandListener implements CommandExecutor {
 				ItemMeta itemMeta = item.getItemMeta();
 				itemMeta.setDisplayName(meta.getDisplayName());
 				item.setItemMeta(itemMeta);
+				List<String> lore = recipe.getDescription() == null ? null : recipe.getDescription().stream()
+					.map(line -> "§r§f" + line)
+					.toList();
+				item.setLore(lore);
 				pane.addItem(new GuiItem(item, ev -> ev.setCancelled(true)));
 			}
 		}
@@ -239,7 +243,7 @@ public class CommandListener implements CommandExecutor {
 		Player pSender = (Player)sender;
 
 		PaginatedPane paginatedPane = new PaginatedPane(0, 0, 9, 5);
-		List<BRecipe> eligible = BRecipe.getAllRecipes().stream().filter(recipe -> recipe.getOptionalID().isPresent()).toList();
+		List<BRecipe> eligible = BRecipe.getAllRecipes().stream().filter(recipe -> recipe.getOptionalID().isPresent()).filter(recipe -> !recipe.isHidden()).toList();
 		List<List<BRecipe>> pageRecipes = Lists.partition(eligible, 5*9);
 		ChestGui gui = new ChestGui(6, MessageFormat.format("{0} ({1}/{2})", GetText.tr("Crafted Brews"), 1, pageRecipes.size()));
 

--- a/src/com/dre/brewery/recipe/BRecipe.java
+++ b/src/com/dre/brewery/recipe/BRecipe.java
@@ -36,7 +36,7 @@ public class BRecipe {
 	private String[] name;
 	private boolean saveInData; // If this recipe should be saved in data and loaded again when the server restarts. Applicable to non-config recipes
 	private String optionalID; // ID that might be given by the config
-	private List<String> description; // The text that shows when a brew hasn't been crafted yet in the collection
+	private List<String> undiscoveredLore; // The text that shows when a brew hasn't been crafted yet in the collection
 	private boolean hidden; // Whether to hide this brew from the collection
 
 	// brewing
@@ -111,7 +111,7 @@ public class BRecipe {
 			return null;
 		}
 
-		recipe.description = BUtil.loadCfgStringList(configSectionRecipes, recipeId + ".description");;
+		recipe.undiscoveredLore = BUtil.loadCfgStringList(configSectionRecipes, recipeId + ".undiscoveredLore");;
 		recipe.hidden = configSectionRecipes.getBoolean(recipeId + ".hidden", false);
 
 		recipe.ingredients = loadIngredients(configSectionRecipes, recipeId);
@@ -668,8 +668,8 @@ public class BRecipe {
 		return Optional.ofNullable(optionalID);
 	}
 
-	public List<String> getDescription() {
-		return description;
+	public List<String> getUndiscoveredLore() {
+		return undiscoveredLore;
 	}
 
 	public boolean isHidden() {
@@ -798,8 +798,8 @@ public class BRecipe {
 
 	// Setters
 
-	public void setDescription(List<String> description) {
-		this.description = description;
+	public void setUndiscoveredLore(List<String> description) {
+		this.undiscoveredLore = description;
 	}
 
 	public void setHidden(boolean hidden) {
@@ -953,11 +953,11 @@ public class BRecipe {
 		}
 
 
-		public Builder addDescriptionLine(String line) {
-			if (recipe.description == null) {
-				recipe.description = new ArrayList<>();
+		public Builder addUndiscoveredLore(String line) {
+			if (recipe.undiscoveredLore == null) {
+				recipe.undiscoveredLore = new ArrayList<>();
 			}
-			recipe.description.add(line);
+			recipe.undiscoveredLore.add(line);
 			return this;
 		}
 

--- a/src/com/dre/brewery/recipe/BRecipe.java
+++ b/src/com/dre/brewery/recipe/BRecipe.java
@@ -36,6 +36,8 @@ public class BRecipe {
 	private String[] name;
 	private boolean saveInData; // If this recipe should be saved in data and loaded again when the server restarts. Applicable to non-config recipes
 	private String optionalID; // ID that might be given by the config
+	private List<String> description; // The text that shows when a brew hasn't been crafted yet in the collection
+	private boolean hidden; // Whether to hide this brew from the collection
 
 	// brewing
 	private List<RecipeItem> ingredients = new ArrayList<>(); // Items and amounts
@@ -108,6 +110,9 @@ public class BRecipe {
 			P.p.errorLog(recipeId + ": Recipe Name invalid");
 			return null;
 		}
+
+		recipe.description = BUtil.loadCfgStringList(configSectionRecipes, recipeId + ".description");;
+		recipe.hidden = configSectionRecipes.getBoolean(recipeId + ".hidden", false);
 
 		recipe.ingredients = loadIngredients(configSectionRecipes, recipeId);
 		if (recipe.ingredients == null || recipe.ingredients.isEmpty()) {
@@ -663,6 +668,14 @@ public class BRecipe {
 		return Optional.ofNullable(optionalID);
 	}
 
+	public List<String> getDescription() {
+		return description;
+	}
+
+	public boolean isHidden() {
+		return hidden;
+	}
+
 	public List<RecipeItem> getIngredients() {
 		return ingredients;
 	}
@@ -784,6 +797,14 @@ public class BRecipe {
 	}
 
 	// Setters
+
+	public void setDescription(List<String> description) {
+		this.description = description;
+	}
+
+	public void setHidden(boolean hidden) {
+		this.hidden = hidden;
+	}
 
 	/**
 	 * When Changing ingredients, Accepted Lists have to be updated in BCauldronRecipe
@@ -931,6 +952,19 @@ public class BRecipe {
 			recipe = new BRecipe(names, PotionColor.WATER);
 		}
 
+
+		public Builder addDescriptionLine(String line) {
+			if (recipe.description == null) {
+				recipe.description = new ArrayList<>();
+			}
+			recipe.description.add(line);
+			return this;
+		}
+
+		public Builder setHidden(boolean hidden) {
+			recipe.hidden = hidden;
+			return this;
+		}
 
 		public Builder addIngredient(RecipeItem... item) {
 			Collections.addAll(recipe.ingredients, item);


### PR DESCRIPTION
When viewing a recipe you haven't crafted yet in the collection, the `description` will show as the barrier's lore. This can be used to give hints on how to make the brew, or whatever else the server owner wants. Field is optional.

When `hidden` is true, the recipe will not show in the collection. This allows server owners to create secret or admin-only brews.