### PR TITLE
Fix cauldron creating brews with incorrect age time and recipe name

### DIFF
--- a/src/com/dre/brewery/BIngredients.java
+++ b/src/com/dre/brewery/BIngredients.java
@@ -124,7 +124,7 @@ public class BIngredients {
 			int quality = (int) Math.round((getIngredientQuality(cookRecipe) + getCookingQuality(cookRecipe, false)) / 2.0);
 			int alc = (int) Math.round(cookRecipe.getAlcohol() * ((float) quality / 10.0f));
 			P.p.debugLog("cooked potion has Quality: " + quality + ", Alc: " + alc);
-			brew = new Brew(this, quality, alc, (byte)0, quality, alc, liquidType, cookedName, false, false, false, 0);
+			brew = new Brew(this, quality, alc, (byte)0, 0, alc, liquidType, cookRecipe.getRecipeName(), false, false, false, 0);
 			BrewLore lore = new BrewLore(brew, potionMeta);
 			lore.updateQualityStars(false);
 			lore.updateCustomLore();

--- a/src/com/dre/brewery/Brew.java
+++ b/src/com/dre/brewery/Brew.java
@@ -29,11 +29,7 @@ import org.mini2Dx.gettext.GetText;
 import java.io.*;
 import java.security.InvalidKeyException;
 import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * Represents the liquid in the brewed Potions
@@ -232,18 +228,17 @@ public class Brew implements Cloneable {
 					return true;
 				}
 			}
-
-			if (quality > 0) {
-				currentRecipe = ingredients.getBestRecipe(wood, ageTime, distillRuns > 0, liquidType);
-				if (currentRecipe != null) {
+		}
+		if (quality > 0) {
+			currentRecipe = ingredients.getBestRecipe(wood, ageTime, distillRuns > 0, liquidType);
+			if (currentRecipe != null) {
 					/*if (!immutable) {
 						this.quality = calcQuality();
 					}*/
-					P.p.log("A Brew was made from Recipe: '" + name + "' which could not be found. '" + currentRecipe.getRecipeName() + "' used instead!");
-					return true;
-				} else {
-					P.p.errorLog("A Brew was made from Recipe: '" + name + "' which could not be found!");
-				}
+				P.p.log("A Brew was made from Recipe: '" + name + "' which could not be found. '" + currentRecipe.getRecipeName() + "' used instead!");
+				return true;
+			} else {
+				P.p.errorLog("A Brew was made from Recipe: '" + name + "' which could not be found!");
 			}
 		}
 		return false;
@@ -423,7 +418,7 @@ public class Brew implements Cloneable {
 		if (currentRecipe != null && quality > 0) {
 			return currentRecipe.getEffects();
 		}
-		return null;
+		return Collections.emptyList();
 	}
 
 	/**

--- a/src/com/dre/brewery/lore/BrewLore.java
+++ b/src/com/dre/brewery/lore/BrewLore.java
@@ -173,9 +173,15 @@ public class BrewLore {
 	 */
 	public void updateAgeLore(boolean qualityColor) {
 		if (brew.isStripped()) return;
-		String prefix;
+		if (brew.hasRecipe() && brew.getCurrentRecipe().getAge() < 1) return;
 		float age = brew.getAgeTime();
-		int quality = brew.getIngredients().getAgeQuality(brew.getCurrentRecipe(), age);
+		String prefix;
+		int quality;
+		if (brew.hasRecipe()) {
+			quality = brew.getIngredients().getAgeQuality(brew.getCurrentRecipe(), age);
+		} else {
+			quality = 0;
+		}
 		if (qualityColor && !brew.isUnlabeled() && brew.hasRecipe()) {
 			prefix = getQualityColor(quality);
 		} else {
@@ -435,7 +441,7 @@ public class BrewLore {
 	 * Adds the Effect names to the Items description
  	 */
 	public void addOrReplaceEffects(List<BEffect> effects, int quality) {
-		if (!P.use1_9 && effects != null) {
+		if (!P.use1_9) {
 			for (BEffect effect : effects) {
 				if (!effect.isHidden()) {
 					effect.writeInto(meta, quality);


### PR DESCRIPTION
A brew taken from a cauldron is saved with its quality in place of its age time, and its item name in place of its recipe name. This causes some brews to throw exceptions when drinking or sealing.

If a brew does not have a recipe set, the plugin will try to set a recipe based on the ingredients. Most broken brews created in an older version of the plugin will be functional again.